### PR TITLE
Feat multiselect option styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "tsc": "tsc --noEmit",
     "lint": "eslint ./src ./example ./website --ext .js,.jsx,.ts,.tsx",
     "test": "jest",
+    "test:update": "jest __tests__ -u",
     "expo-start": "yarn --cwd example start",
     "expo-android": "yarn --cwd example android",
     "expo-ios": "yarn --cwd example ios",

--- a/src/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Select.test.tsx.snap
@@ -529,6 +529,7 @@ exports[`Select with multi selection should generate Select with multi selection
                     "display": "flex",
                     "justifyContent": "center",
                   },
+                  undefined,
                   Object {
                     "width": "100%",
                   },

--- a/src/components/multi-select/components/selected-option/index.tsx
+++ b/src/components/multi-select/components/selected-option/index.tsx
@@ -22,13 +22,17 @@ type Props = {
 
 type FromSelectComponentProps = Pick<
     ComponentPropsWithRef<typeof Select>,
-    'selectControlTextStyle' | 'placeholderText' | 'placeholderTextColor'
+    | 'selectControlTextStyle'
+    | 'placeholderText'
+    | 'placeholderTextColor'
+    | 'multiSelectionOptionStyle'
 >;
 
 export const MultiSelectedOption = ({
     isPlaceholder = false,
     option,
     selectControlTextStyle,
+    multiSelectionOptionStyle,
     placeholderText,
     placeholderTextColor,
     optionWidth,
@@ -45,6 +49,7 @@ export const MultiSelectedOption = ({
                 isPlaceholder
                     ? styles.placeholderText
                     : styles.multiSelectionOption,
+                multiSelectionOptionStyle,
                 { width: optionWidth },
             ]}
             onPress={() =>
@@ -60,7 +65,7 @@ export const MultiSelectedOption = ({
                         color: option?.label
                             ? StyleSheet.flatten(selectControlTextStyle)
                                   ?.color || COLORS.BLACK
-                            : placeholderTextColor || COLORS.GRAY,
+                            : placeholderTextColor,
                     },
                 ]}
             >

--- a/src/components/multi-select/index.tsx
+++ b/src/components/multi-select/index.tsx
@@ -28,6 +28,7 @@ type FromSelectComponentProps = Pick<
     | 'searchPattern'
     | 'searchable'
     | 'multiSelection'
+    | 'multiSelectionOptionStyle'
     | 'placeholderTextColor'
 >;
 
@@ -59,6 +60,7 @@ export const MultiSelect = ({
     searchValue,
     setPosition,
     multiSelection,
+    multiSelectionOptionStyle,
 }: Props) => {
     const { width } = useWindowDimensions();
     const selectedOptionTyped = selectedOption as OptionType[];
@@ -116,6 +118,7 @@ export const MultiSelect = ({
                     optionWidth={optionWidth()}
                     placeholderText={placeholderText}
                     selectControlTextStyle={selectControlTextStyle}
+                    multiSelectionOptionStyle={multiSelectionOptionStyle}
                     onPressRemove={onPressRemove}
                 />
             );

--- a/src/components/select-control/index.tsx
+++ b/src/components/select-control/index.tsx
@@ -61,6 +61,7 @@ type FromSelectComponentProps = Pick<
     | 'selectControlClearOptionImageStyle'
     | 'customLeftIconSource'
     | 'customLeftIconStyles'
+    | 'multiSelectionOptionStyle'
 >;
 
 type SelectControlProps = OptionalToRequired<
@@ -110,6 +111,7 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
             selectControlClearOptionA11yLabel,
             selectControlOpenDropdownA11yLabel,
             selectControlButtonsContainerStyle,
+            multiSelectionOptionStyle,
             hideSelectControlArrow,
             onSelect,
             selectControlTextStyle,
@@ -263,6 +265,7 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
                     searchable={searchable}
                     selectControlStyle={selectControlStyle}
                     selectControlTextStyle={selectControlTextStyle}
+                    multiSelectionOptionStyle={multiSelectionOptionStyle}
                     selectedOption={selectedOption as OptionType[]}
                     setPosition={setPosition}
                     onPressRemove={onPressRemove}
@@ -301,7 +304,7 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
                             color: selectedOptionTyped?.label
                                 ? StyleSheet.flatten(selectControlTextStyle)
                                       ?.color || COLORS.BLACK
-                                : placeholderTextColor || COLORS.GRAY,
+                                : placeholderTextColor,
                         },
                     ]}
                 >

--- a/src/components/select-input/index.tsx
+++ b/src/components/select-input/index.tsx
@@ -105,7 +105,7 @@ export const SelectInput = ({
             accessibilityLabel="Place text"
             editable={!disabled}
             placeholder={resolvePlaceholder()}
-            placeholderTextColor={placeholderTextColor || COLORS.GRAY}
+            placeholderTextColor={placeholderTextColor}
             style={
                 disabled
                     ? [

--- a/src/components/select/index.tsx
+++ b/src/components/select/index.tsx
@@ -18,6 +18,7 @@ import {
 
 import {
     ANIMATION_DURATION,
+    COLORS,
     ITEM_HEIGHT,
     MAX_HEIGHT_LIST,
 } from '../../constants/styles';
@@ -38,44 +39,58 @@ import { SelectControl } from '../select-control';
 export const Select = forwardRef(
     (props: SelectProps, ref: ForwardedRef<SelectRef>) => {
         const {
+            // Required
             options,
-            clearable = true,
-            closeDropdownOnSelect = true,
-            defaultOption,
-            disabled = false,
-            flatListProps,
-            multiSelection = false,
-            hideSelectControlArrow,
-            animated = false,
-            animationDuration = ANIMATION_DURATION,
-            noOptionsText = 'No options',
+            // Callbacks
             onSelect,
             onDropdownOpened,
             onDropdownClosed,
-            optionSelectedStyle,
-            optionStyle,
-            optionTextStyle,
+            // Texts
+            noOptionsText = 'No options',
             placeholderText = 'Select...',
-            placeholderTextColor,
+            // Animations
+            animated = false,
+            animationDuration = ANIMATION_DURATION,
+            // Behaviour
+            clearable = true,
+            closeDropdownOnSelect = true,
+            disabled = false,
+            scrollToSelectedOption = true,
+            hideSelectControlArrow = false,
+            // Additional features
+            defaultOption,
+            flatListProps,
+            // Search
             searchable = false,
             searchPattern = (payload: string) => `(${payload})`,
-            scrollToSelectedOption = true,
+            // Multiselect
+            multiSelection = false,
+            // Custom components
+            NoOptionsComponent,
+            OptionComponent,
+            // Custom sources
+            customLeftIconSource,
+            // Colors
+            placeholderTextColor = COLORS.GRAY,
+            // Accessibility
+            selectControlClearOptionA11yLabel,
+            selectControlOpenDropdownA11yLabel,
+            // Styles
+            optionStyle,
+            optionsListStyle,
+            optionTextStyle,
+            optionSelectedStyle,
             selectContainerStyle,
             selectControlArrowImageStyle,
             selectControlButtonsContainerStyle,
             selectControlClearOptionButtonStyle,
             selectControlClearOptionImageStyle,
             selectControlClearOptionButtonHitSlop,
-            selectControlClearOptionA11yLabel,
-            selectControlOpenDropdownA11yLabel,
             selectControlDisabledStyle,
             selectControlStyle,
             selectControlTextStyle,
-            optionsListStyle,
-            customLeftIconSource,
             customLeftIconStyles,
-            NoOptionsComponent,
-            OptionComponent,
+            multiSelectionOptionStyle,
         } = props;
         const [state, dispatch] = useReducer(reducer, initialData);
         const {
@@ -345,6 +360,7 @@ export const Select = forwardRef(
                     hideSelectControlArrow={hideSelectControlArrow}
                     isOpened={isOpened}
                     multiSelection={multiSelection}
+                    multiSelectionOptionStyle={multiSelectionOptionStyle}
                     options={options}
                     placeholderText={placeholderText}
                     placeholderTextColor={placeholderTextColor}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,14 +230,6 @@ export interface SelectProps {
      */
     selectControlOpenDropdownA11yLabel?: string;
 
-    /**
-     * selectControlCloseDropdownA11yLabel
-     *
-     * @category Accessibility
-     * @default "Close a dropdown"
-     */
-    selectControlCloseDropdownA11yLabel?: string;
-
     //---STYLES---//
     /**
      *  Style of arrow image

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,41 +32,213 @@ export type OptionComponentProps = Pick<
  * `<Select />` component props
  */
 export interface SelectProps {
+    //---REQUIRED---//
     /**
      *  Options to show on the list
      *
      *  @category Required
      */
     options: OptionsType;
+
+    //---CALLBACKS---//
     /**
      * Callback that is called when option is selected
      *
      * @param option Selected option
      * @param optionIndex Selected option index
-     * @category Common
+     * @category Callback
      */
     onSelect?: (option: OptionType | null, optionIndex: number) => void;
 
     /**
      * Callback that is called when dropdown is opened
      *
-     * @category Common
+     * @category Callback
      */
     onDropdownOpened?: () => void;
 
     /**
      * Callback that is called when dropdown is closed
      *
-     * @category Common
+     * @category Callback
      */
     onDropdownClosed?: () => void;
 
+    //---TEXTS---//
+    /**
+     * No options text
+     *
+     * @category Text
+     * @default "No options"
+     */
+    noOptionsText?: string;
+
+    /**
+     * Placeholder text
+     *
+     * @category Text
+     * @default "Select..."
+     */
+    placeholderText?: string;
+
+    //---ANIMATIONS---//
+    /**
+     *  If `true` toggling the select is animated
+     *
+     *  @category Animations
+     *  @default false
+     */
+    animated?: boolean;
+
+    /**
+     *  Animation duration in ms
+     *
+     *  @category Animations
+     *  @default 200
+     */
+    animationDuration?: number;
+
+    //---BEHAVIOURS---//
+    /**
+     *  If `true` enables a clear button to remove selected option
+     *
+     *  @category Behaviour
+     *  @default true
+     */
+    clearable?: boolean;
+
+    /**
+     * If `true` close a dropdown after selected option
+     *
+     * @category Behaviour
+     * @default true
+     */
+    closeDropdownOnSelect?: boolean;
+
+    /**
+     *  If `true` disable a select control
+     *
+     *  @category Behaviour
+     *  @default true
+     */
+    disabled?: boolean;
+
+    /**
+     * If `true` options list is scrolled to the selected option
+     *
+     * @category Behaviour
+     * @default true
+     */
+    scrollToSelectedOption?: boolean;
+
+    /**
+     *  If `true` hide select control arrow
+     *
+     *  @category Behaviour
+     *  @default false
+     */
+    hideSelectControlArrow?: boolean;
+
+    //---ADDITIONAL-FEATURES---//
     /**
      *  Set a default option
-     *  @category Common
+     *  @category Additional Features
      */
     defaultOption?: OptionType;
 
+    /**
+     *  `FlatListProps` imported from `react-native`
+     *
+     *  @category Additional Features
+     */
+    flatListProps?: Omit<
+        FlatListProps<OptionType>,
+        'data' | 'renderItem' | 'ListEmptyComponent'
+    >;
+
+    //---SEARCH---//
+    /**
+     *  If `true` let user search in a select options by typing in select
+     *
+     *  @default false
+     *  @category Search
+     */
+    searchable?: boolean;
+    /**
+     *  Regex definition for searching options
+     *
+     *  @default (payload: string) => `(${payload})`
+     *  @category Search
+     */
+    searchPattern?: (payload: string) => string;
+
+    //---MULTISELECT---//
+    /**
+     *  if `true` then multi option can be picked
+     *
+     *  @category Multiselect
+     *  @default false
+     */
+    multiSelection?: boolean;
+
+    //---CUSTOM-COMPONENT---//
+    /**
+     * NoOptionsComponent
+     *
+     * @category Custom Component
+     */
+    NoOptionsComponent?: JSX.Element;
+    /**
+     * OptionComponent
+     *
+     * @param props OptionComponentProps
+     * @category Custom Component
+     */
+    OptionComponent?: (props: OptionComponentProps) => JSX.Element;
+
+    //---CUSTOM-SOURCES---//
+    /**
+     *  Custom left icon source
+     *
+     *  @category Custom Sources
+     */
+    customLeftIconSource?: ImageSourcePropType;
+
+    //---COLORS---//
+    /**
+     * Placeholder text color
+     *
+     * @category Colors
+     * @default "Select..."
+     */
+    placeholderTextColor?: string;
+
+    //---ACCESSIBILITY---//
+    /**
+     * selectControlClearOptionA11yLabel
+     *
+     * @category Accessibility
+     * @default "Clear a chosen option"
+     */
+    selectControlClearOptionA11yLabel?: string;
+
+    /**
+     * selectControlOpenDropdownA11yLabel
+     *
+     * @category Accessibility
+     * @default "Open a dropdown"
+     */
+    selectControlOpenDropdownA11yLabel?: string;
+
+    /**
+     * selectControlCloseDropdownA11yLabel
+     *
+     * @category Accessibility
+     * @default "Close a dropdown"
+     */
+    selectControlCloseDropdownA11yLabel?: string;
+
+    //---STYLES---//
     /**
      *  Style of arrow image
      *
@@ -138,172 +310,39 @@ export interface SelectProps {
     optionsListStyle?: StyleProp<ViewStyle>;
 
     /**
-     *  If `true` hide select control arrow
-     *
-     *  @default false
-     *  @category Common
-     */
-    hideSelectControlArrow?: boolean;
-
-    /**
-     *  If `true` enables a clear button to remove selected option
-     *
-     *  @default true
-     *  @category Common
-     */
-    clearable?: boolean;
-    /**
-     *  If `true` disable a select control
-     *
-     *  @default true
-     *  @category Common
-     */
-    disabled?: boolean;
-    /**
-     *  If `true` let user search in a select options by typing in select
-     *
-     *  @default false
-     *  @category Common
-     */
-    searchable?: boolean;
-    /**
-     *  Regex definition for searching options
-     *
-     *  @default (payload: string) => `(${payload})`
-     *  @category Common
-     */
-    searchPattern?: (payload: string) => string;
-    /**
-     *  `FlatListProps` imported from `react-native`
-     *
-     *  @category Common
-     */
-    flatListProps?: Omit<
-        FlatListProps<OptionType>,
-        'data' | 'renderItem' | 'ListEmptyComponent'
-    >;
-    /**
-     *  if `true` then multi option can be picked
-     *
-     *  @category Common
-     *  @default false
-     */
-    multiSelection?: boolean;
-    /**
-     * If `true` close a dropdown after selected option
-     *
-     * @category Common
-     * @default true
-     */
-    closeDropdownOnSelect?: boolean;
-    /**
-     * Placeholder text
-     *
-     * @category Common
-     * @default "Select..."
-     */
-    placeholderText?: string;
-    /**
-     * Placeholder text
-     *
-     * @category Common
-     * @default "Select..."
-     */
-    placeholderTextColor?: string;
-    /**
-     * If `true` options list is scrolled to the selected option
-     *
-     * @category Common
-     * @default true
-     */
-    scrollToSelectedOption?: boolean;
-    /**
-     * No options text
-     *
-     * @category Common
-     * @default "No options"
-     */
-    noOptionsText?: string;
-    /**
      * Style of single option
      *
      * @category Styles
      */
     optionStyle?: StyleProp<ViewStyle>;
+
     /**
      * Style of single option text
      *
      * @category Styles
      */
     optionTextStyle?: StyleProp<TextStyle>;
+
     /**
      * Style of selected single option
      *
      * @category Styles
      */
     optionSelectedStyle?: StyleProp<ViewStyle>;
-    /**
-     * selectControlClearOptionA11yLabel
-     *
-     * @category Accessibility
-     * @default "Clear a chosen option"
-     */
-    selectControlClearOptionA11yLabel?: string;
-    /**
-     * selectControlOpenDropdownA11yLabel
-     *
-     * @category Accessibility
-     * @default "Open a dropdown"
-     */
-    selectControlOpenDropdownA11yLabel?: string;
-    /**
-     * selectControlCloseDropdownA11yLabel
-     *
-     * @category Accessibility
-     * @default "Close a dropdown"
-     */
-    selectControlCloseDropdownA11yLabel?: string;
 
-    /**
-     * NoOptionsComponent
-     *
-     * @category Custom Component
-     */
-    NoOptionsComponent?: JSX.Element;
-
-    /**
-     * OptionComponent
-     *
-     * @param props OptionComponentProps
-     * @category Custom Component
-     */
-    OptionComponent?: (props: OptionComponentProps) => JSX.Element;
-    /**
-     *  If `true` toggling the select is animated
-     *
-     *  @category Styles
-     *  @default false
-     */
-    animated?: boolean;
-    /**
-     *  Animation duration in ms
-     *
-     *  @category Styles
-     *  @default 200
-     */
-    animationDuration?: number;
-    /**
-     *  Custom left icon source
-     *
-     *  @category Styles
-     */
-    customLeftIconSource?: ImageSourcePropType;
     /**
      *  Custom left icon styles
      *
      *  @category Styles
      */
     customLeftIconStyles?: StyleProp<ImageStyle>;
+
+    /**
+     *  Custom multiselection option style
+     *
+     *  @category Styles
+     */
+    multiSelectionOptionStyle?: StyleProp<ViewStyle>;
 }
 
 /**

--- a/website/docs/api/accessibility.md
+++ b/website/docs/api/accessibility.md
@@ -4,11 +4,6 @@ title: Accessibility props
 sidebar_label: Accessibility
 ---
 
-### selectControlCloseDropdownA11yLabel
-```typescript jsx
-selectControlCloseDropdownA11yLabel?: string;
-```
-
 ### selectControlClearOptionA11yLabel
 ```typescript jsx
 selectControlClearOptionA11yLabel?: string;

--- a/website/docs/api/styles.md
+++ b/website/docs/api/styles.md
@@ -93,3 +93,9 @@ Style of selected single option
 optionsListStyle?: StyleProp<ViewStyle>;
 ```
 Style of options list
+
+### multiSelectionOptionStyle
+```typescript jsx
+multiSelectionOptionStyle?: StyleProp<ViewStyle>;
+```
+Custom multiselection option styles


### PR DESCRIPTION
1. Added style customization for multiselect option item `MultiSelectedOption`
2. `SelectProps` type refactor (Too much props, hard to read)
3. Added script `"test:update": "jest __tests__ -u"` for updating snapshots
4. Removed unused accessability type
5. Added `placeholderTextColor = COLORS.GRAY` as default value