### PR TITLE
refactor: only one instance for options in component

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -12,6 +12,7 @@
     "detox-ios-test": "detox test -c ios",
     "detox-android-build": "detox build -c android.emu.release",
     "detox-android-test": "detox test -c android.emu.release",
+    "detox-clean": "detox clean-framework-cache && detox build-framework-cache",
     "tsc": "tsc --noEmit",
     "clean": "rm -Rf .turbo && rm -Rf node_modules"
   },

--- a/packages/react-native-select-pro/src/components/select-control/index.tsx
+++ b/packages/react-native-select-pro/src/components/select-control/index.tsx
@@ -31,7 +31,6 @@ type FromSelectComponentProps = Pick<
     | 'clearable'
     | 'animated'
     | 'animationDuration'
-    | 'options'
     | 'disabled'
     | 'searchable'
     | 'searchPattern'
@@ -55,7 +54,8 @@ type FromSelectComponentProps = Pick<
     | 'customLeftIconSource'
     | 'customLeftIconStyles'
     | 'multiSelectionOptionStyle'
->;
+> &
+    Pick<State, 'optionsData'>;
 
 type SelectControlProps = OptionalToRequired<
     {
@@ -81,7 +81,7 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
             onPressSelectControl,
             dispatch,
             clearable,
-            options,
+            optionsData,
             disabled,
             multiSelection,
             placeholderText,
@@ -134,7 +134,7 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
             if (!disabled) {
                 let removedOption = selectedOption;
                 let removedOptionIndex = selectedOptionIndex;
-                if (multiSelection && !isSectionOptionsType(options)) {
+                if (multiSelection && !isSectionOptionsType(optionsData)) {
                     let removedSelectedOptions: null | OptionType[] = [];
                     removedSelectedOptions = (selectedOption as OptionType[]).filter(
                         (selected) => selected.value !== (option as OptionType).value,
@@ -142,7 +142,9 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
                     if (removedSelectedOptions.length === 0) {
                         removedSelectedOptions = null;
                     }
-                    const foundIndex = options.findIndex(({ value }) => value === option?.value);
+                    const foundIndex = optionsData.findIndex(
+                        ({ value }) => value === option?.value,
+                    );
                     removedOptionIndex = foundIndex;
                     removedOption = option;
                     const resolveSelectedOptionIndex = (selectedOptionIndex as number[]).filter(
@@ -173,10 +175,6 @@ export const SelectControl = forwardRef<View, SelectControlProps>(
                             payload: '',
                         });
                     }
-                    dispatch({
-                        type: Action.SetOptionsData,
-                        payload: options,
-                    });
                 }
                 if (onSelect) {
                     onSelect(null, -1);

--- a/packages/react-native-select-pro/src/components/select/index.tsx
+++ b/packages/react-native-select-pro/src/components/select/index.tsx
@@ -81,7 +81,7 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
         sectionHeaderTextStyle,
         sectionHeaderContainerStyle,
     } = props;
-    const [state, dispatch] = useReducer(reducer, initialData);
+    const [state, dispatch] = useReducer(reducer, { ...initialData, optionsData: options });
     const {
         isOpened,
         selectedOption,
@@ -96,17 +96,17 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
     const selectedOptionTyped = selectedOption as OptionType;
 
     const containerRef = useRef<View>(null);
-    const isMultiSelection = multiSelection && !isSectionOptionsType(options);
-    const isSearchable = searchable && !isSectionOptionsType(options);
+    const isMultiSelection = multiSelection && !isSectionOptionsType(optionsData);
+    const isSearchable = searchable && !isSectionOptionsType(optionsData);
 
     useEffect(() => {
-        if (!Array.isArray(options)) {
+        if (!Array.isArray(optionsData)) {
             // eslint-disable-next-line no-console
             console.error('You must pass array in the options prop');
             return;
         }
 
-        if (options.length > 0) {
+        if (optionsData.length > 0) {
             dispatch({ type: Action.SetOptionsData, payload: options });
 
             const isValidPassDefaultOption =
@@ -115,10 +115,10 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
                 Object.hasOwn(defaultOption, 'label');
 
             if (isValidPassDefaultOption) {
-                const isSectionData = isSectionOptionsType(options);
+                const isSectionData = isSectionOptionsType(optionsData);
                 const foundIndex = isSectionData
-                    ? getReducedSectionData(options).indexOf(defaultOption)
-                    : options.indexOf(defaultOption);
+                    ? getReducedSectionData(optionsData).indexOf(defaultOption)
+                    : optionsData.indexOf(defaultOption);
 
                 dispatch({
                     type: Action.SelectOption,
@@ -131,7 +131,7 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
         }
         // TODO
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [options]);
+    }, [optionsData]);
 
     useImperativeHandle(ref, () => ({
         clear: () => {
@@ -139,7 +139,6 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
                 type: Action.SelectOption,
                 payload: { selectedOption: null, selectedOptionIndex: -1 },
             });
-            dispatch({ type: Action.SetOptionsData, payload: options });
             if (onRemove) {
                 onRemove(selectedOption, selectedOptionIndex);
             }
@@ -230,7 +229,7 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
                 });
             }
         }
-        dispatch({ type: Action.SetOptionsData, payload: options });
+
         if (option) {
             hideKeyboardIfNeeded();
         }
@@ -298,7 +297,6 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
 
     const onOutsidePress: OnOutsidePress = () => {
         dispatch({ type: Action.Close });
-        dispatch({ type: Action.SetOptionsData, payload: options });
         if (isSearchable && selectedOptionTyped?.label) {
             dispatch({
                 type: Action.SetSearchValue,
@@ -334,7 +332,7 @@ export const Select = forwardRef((props: SelectProps, ref: ForwardedRef<SelectRe
                 isOpened={isOpened}
                 multiSelection={isMultiSelection}
                 multiSelectionOptionStyle={multiSelectionOptionStyle}
-                options={options}
+                optionsData={optionsData}
                 placeholderText={placeholderText}
                 placeholderTextColor={placeholderTextColor}
                 searchPattern={searchPattern}


### PR DESCRIPTION
Rely on one instance for options:
1. Update initial state based on passed options prop
2. Remove unnecessary dispatches to update optionsData state prop