### PR TITLE
fix: FlatList initialScrollIndex

### DIFF
--- a/packages/react-native-select-pro/src/components/flat-options-list/flat-options-list.tsx
+++ b/packages/react-native-select-pro/src/components/flat-options-list/flat-options-list.tsx
@@ -1,7 +1,8 @@
-import React, { memo } from 'react';
+import React, { memo, useRef } from 'react';
 import isEqual from 'react-fast-compare';
 import { FlatList } from 'react-native';
 
+import { ERRORS, logError } from '../../helpers';
 import { NoOptions } from '../no-options';
 
 import type { FlatOptionsListProps } from './flat-options-list.types';
@@ -16,6 +17,21 @@ export const FlatOptionsList = memo(
         accessibilityState,
         disabled,
     }: FlatOptionsListProps<T>) => {
+        const flatListRef = useRef<FlatList>(null);
+
+        const scrollToIndex = () => {
+            if (flatListRef.current) {
+                try {
+                    flatListRef.current.scrollToIndex({
+                        animated: false,
+                        index: initialScrollIndex === -1 ? 0 : initialScrollIndex,
+                    });
+                } catch {
+                    logError(ERRORS.SCROLL_TO_LOCATION);
+                }
+            }
+        };
+
         return (
             <FlatList
                 testID="Options list"
@@ -25,13 +41,13 @@ export const FlatOptionsList = memo(
                 keyboardShouldPersistTaps="handled"
                 persistentScrollbar={true}
                 ListEmptyComponent={<NoOptions />}
-                initialScrollIndex={initialScrollIndex}
                 scrollEnabled={!disabled}
                 {...flatListProps}
                 data={resolvedData}
                 getItemLayout={getItemLayout}
                 renderItem={renderItem}
                 keyExtractor={({ value }) => value}
+                onLayout={scrollToIndex}
             />
         );
     },


### PR DESCRIPTION
Items above `initialScrollIndex` on a fixed height list won't render, there are numerous bugs on react-native FlatList regarding this issue dated even back to 2015:

* https://github.com/facebook/react-native/issues/1831
* https://github.com/facebook/react-native/issues/8607
* https://github.com/facebook/react-native/issues/13316
* https://github.com/meliorence/react-native-snap-carousel/issues/238

Problem: 

Using this style which renders the whole list without the need to scroll it (applied on a really small list of 5 items): 

```json

optionsList: {
        maxHeight: 300
      },
      option: {
        container: {
          width: "100%",
          borderRadius: 8
        }
    }

```

...results in this issue shown below where the items above the `initialScrollIndex` are not rendered: 

https://github.com/MobileReality/react-native-select-pro/assets/717975/87ca13f1-e1a1-4f89-a7b7-10125a27ca7d

After applying the fix proposed in this PR: 


https://github.com/MobileReality/react-native-select-pro/assets/717975/e1b024a8-3eb6-437c-8c42-6773e892e02b

This is without the `maxHeight: mvs(300)` so it works fine in all scenarios:

https://github.com/MobileReality/react-native-select-pro/assets/717975/7d76a60e-3b0f-4a99-abda-a80ef4cc28d6


These changes align with `SectionOptionsList`:

* https://github.com/efstathiosntonas/react-native-select-pro/blob/780db33a4f7912f6a52205c7efac0819a5101e89/packages/react-native-select-pro/src/components/section-options-list/section-options-list.tsx#L71
* https://github.com/efstathiosntonas/react-native-select-pro/blob/780db33a4f7912f6a52205c7efac0819a5101e89/packages/react-native-select-pro/src/components/section-options-list/section-options-list.tsx#L37
