### PR TITLE
feat: add support for multiple default options

### DIFF
--- a/apps/expo/src/constants/routes.ts
+++ b/apps/expo/src/constants/routes.ts
@@ -8,6 +8,7 @@ import { CustomStyles } from '../examples/custom-styles';
 import { ModalExample } from '../examples/modal-example';
 import { MultiSelect } from '../examples/multiselect';
 import { MultiSelectSearchableWithSeparatedOptions } from '../examples/multiselect-searchable-with-separated-options';
+import { MultiSelectWithDefaultOptions } from '../examples/multiselect-with-default-options';
 import { MultiSelectWithHiddenOptions } from '../examples/multiselect-with-hidden-options';
 import { MultiSelectWithSearchable } from '../examples/multiselect-with-searchable';
 import { MultiSelectWithSeparatedOptions } from '../examples/multiselect-with-separated-options';
@@ -114,6 +115,10 @@ export const ROUTES = [
     {
         name: 'MultiSelect with Hidden Options',
         screen: MultiSelectWithHiddenOptions,
+    },
+    {
+        name: 'MultiSelect with Default Options',
+        screen: MultiSelectWithDefaultOptions,
     },
     {
         name: 'TextInputProps',

--- a/apps/expo/src/examples/multiselect-with-default-options.tsx
+++ b/apps/expo/src/examples/multiselect-with-default-options.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Select } from '@mobile-reality/react-native-select-pro';
+
+import { SafeAreaViewWrapper } from '../components/safe-area-view-wrapper';
+import { DATA } from '../constants/data';
+
+export const MultiSelectWithDefaultOptions = () => {
+    return (
+        <SafeAreaViewWrapper>
+            <Select options={DATA} multiple={true} defaultOption={[DATA[0], DATA[1]]} />
+        </SafeAreaViewWrapper>
+    );
+};

--- a/packages/react-native-select-pro/src/helpers/__tests__/get-default-selection-index.test.ts
+++ b/packages/react-native-select-pro/src/helpers/__tests__/get-default-selection-index.test.ts
@@ -1,0 +1,44 @@
+import type { OptionType } from '../../types';
+import { getDefaultSelectionIndex } from '../index';
+
+describe('getDefaultSelectionIndex', () => {
+    const options: OptionType[] = [
+        { label: 'Option 1', value: 'value1' },
+        { label: 'Option 2', value: 'value2' },
+        { label: 'Option 3', value: 'value3' },
+    ];
+
+    it('should return the correct index for a single default option', () => {
+        const defaultOption = { label: 'Option 2', value: 'value2' };
+        expect(getDefaultSelectionIndex(options, defaultOption)).toBe(1);
+    });
+
+    it('should return -1 if the single default option is not found', () => {
+        const defaultOption = { label: 'Option 4', value: 'value4' };
+        expect(getDefaultSelectionIndex(options, defaultOption)).toBe(-1);
+    });
+
+    it('should return an array of indices for multiple default options', () => {
+        const defaultOptions = [
+            { label: 'Option 1', value: 'value1' },
+            { label: 'Option 3', value: 'value3' },
+        ];
+        expect(getDefaultSelectionIndex(options, defaultOptions)).toEqual([0, 2]);
+    });
+
+    it('should return only found indices for multiple default options', () => {
+        const defaultOptions = [
+            { label: 'Option 1', value: 'value1' },
+            { label: 'Option 4', value: 'value4' },
+        ];
+        expect(getDefaultSelectionIndex(options, defaultOptions)).toEqual([0]);
+    });
+
+    it('should return an empty array if no default options are found', () => {
+        const defaultOptions = [
+            { label: 'Option 4', value: 'value4' },
+            { label: 'Option 5', value: 'value5' },
+        ];
+        expect(getDefaultSelectionIndex(options, defaultOptions)).toEqual([]);
+    });
+});

--- a/packages/react-native-select-pro/src/helpers/get-default-selection-index.ts
+++ b/packages/react-native-select-pro/src/helpers/get-default-selection-index.ts
@@ -1,0 +1,24 @@
+import type { OptionType } from '../types';
+
+export const getDefaultSelectionIndex = <T>(
+    flatOptions: OptionType<T>[],
+    defaultOption: OptionType<T> | OptionType<T>[],
+): number | number[] => {
+    if (Array.isArray(defaultOption)) {
+        const foundIndices = defaultOption
+            .map((option) => flatOptions.findIndex((item) => item.value === option.value))
+            .filter((index) => index !== -1);
+
+        if (foundIndices.length > 0) {
+            return foundIndices;
+        }
+    } else {
+        const foundIndex = flatOptions.findIndex((item) => item.value === defaultOption.value);
+
+        if (foundIndex !== -1) {
+            return foundIndex;
+        }
+    }
+
+    return Array.isArray(defaultOption) ? [] : -1;
+};

--- a/packages/react-native-select-pro/src/helpers/index.ts
+++ b/packages/react-native-select-pro/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export { dimensionPercentageToDP } from './dimension-percentage-to-dp';
+export { getDefaultSelectionIndex } from './get-default-selection-index';
 export { getReducedSectionData } from './get-reduced-section-data';
 export { getSectionOptionsIndexes } from './get-section-options-indexes';
 export { isAndroid } from './is-android';

--- a/packages/react-native-select-pro/src/state/types.ts
+++ b/packages/react-native-select-pro/src/state/types.ts
@@ -73,5 +73,5 @@ export type CreateInitialStateType<T> = {
     searchable: boolean;
     animation: boolean | number;
 
-    defaultOption: OptionType<T> | undefined;
+    defaultOption: OptionType<T> | OptionType<T>[] | undefined;
 };

--- a/packages/react-native-select-pro/src/types/types.ts
+++ b/packages/react-native-select-pro/src/types/types.ts
@@ -70,9 +70,9 @@ export interface SelectProps<T = unknown> {
     closeOptionsListOnSelect?: boolean;
 
     /**
-     *  An object that represents the default option for a `Select`.
+     *  An object or array of objects that represents the default option(s) for a `Select`.
      */
-    defaultOption?: OptionType<T>;
+    defaultOption?: OptionType<T> | OptionType<T>[];
 
     /**
      *  Disable a `Select` pressable.


### PR DESCRIPTION
This adds support for passing multiple objects as `defaultOption` to be used together with multiselects. The implementation retains full backwards compatibility with the existing `defaultOption` prop, adding an array option to the existing implementation.

I have also added an example to the Expo app.

This feature is sensible in cases where e.g. a previous selection for a multiselect needs to be restored or some preconfigured selection needs to be configured. The idea was last mentioned in the discussions board here: https://github.com/MobileReality/react-native-select-pro/discussions/225

Please let me know if there are any requirements for a contributing PR that I might have missed or any changes and additions you require in order for this feature to be inegrated.
